### PR TITLE
fix file check

### DIFF
--- a/shared/src/main/java/xyz/lychee/gatekeeper/shared/manager/DataManager.java
+++ b/shared/src/main/java/xyz/lychee/gatekeeper/shared/manager/DataManager.java
@@ -68,7 +68,7 @@ public class DataManager extends AbstractManager implements Runnable {
         this.nicknames.clear();
         this.asns.clear();
 
-        if (Files.notExists(this.dataPath)) {
+        if (Files.exists(this.dataPath)) {
             this.loadDataFile();
         }
         return true;


### PR DESCRIPTION
fixes

```
> gatekeeper reload
[10:09:04 ERROR] [🛡️]: plugins/gatekeeper/data.json
java.nio.file.NoSuchFileException: plugins/gatekeeper/data.json
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92) ~[?:?]
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106) ~[?:?]
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111) ~[?:?]
        at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:213) ~[?:?]
        at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:244) ~[?:?]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:357) ~[?:?]
        at java.base/java.nio.file.Files.newByteChannel(Files.java:399) ~[?:?]
        at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:371) ~[?:?]
        at java.base/java.nio.file.Files.newInputStream(Files.java:154) ~[?:?]
        at xyz.lychee.gatekeeper.shared.manager.DataManager.loadDataFile(DataManager.java:78) ~[?:?]
        at xyz.lychee.gatekeeper.shared.manager.DataManager.reload(DataManager.java:72) ~[?:?]
        at xyz.lychee.gatekeeper.shared.Gatekeeper.reloadManagers(Gatekeeper.java:70) ~[?:?]
        at xyz.lychee.gatekeeper.shared.command.subcommand.ReloadCommand.handleExecution(ReloadCommand.java:22) ~[?:?]
        at xyz.lychee.gatekeeper.shared.command.PermissibleCommand.execute(PermissibleCommand.java:25) ~[?:?]
        at xyz.lychee.gatekeeper.shared.command.CommandHandler.handleExecution(CommandHandler.java:35) ~[?:?]
        at xyz.lychee.gatekeeper.shared.command.PermissibleCommand.execute(PermissibleCommand.java:25) ~[?:?]
        at xyz.lychee.gatekeeper.velocity.VelocityCommand.execute(VelocityCommand.java:21) ~[?:?]
        at xyz.lychee.gatekeeper.velocity.VelocityCommand.execute(VelocityCommand.java:10) ~[?:?]
        at com.velocitypowered.proxy.command.registrar.InvocableCommandRegistrar.lambda$createLiteral$1(InvocableCommandRegistrar.java:82) ~[velocity-3.5.0-SNAPSHOT-607.jar:3.5.0-SNAPSHOT (git-81a5817a-b607)]
        at com.velocitypowered.proxy.command.brigadier.VelocityBrigadierCommandWrapper.run(VelocityBrigadierCommandWrapper.java:61) ~[velocity-3.5.0-SNAPSHOT-607.jar:3.5.0-SNAPSHOT (git-81a5817a-b607)]
        at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:262) ~[velocity-3.5.0-SNAPSHOT-607.jar:3.5.0-SNAPSHOT (git-81a5817a-b607)]
        at com.velocitypowered.proxy.command.VelocityCommandManager.executeImmediately0(VelocityCommandManager.java:237) ~[velocity-3.5.0-SNAPSHOT-607.jar:3.5.0-SNAPSHOT (git-81a5817a-b607)]
        at com.velocitypowered.proxy.command.VelocityCommandManager.lambda$executeAsync$0(VelocityCommandManager.java:283) ~[velocity-3.5.0-SNAPSHOT-607.jar:3.5.0-SNAPSHOT (git-81a5817a-b607)]
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1789) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1474) [?:?]

```